### PR TITLE
fix : Enhance Recipe Detail Page with Dynamic Add/Remove Collection Buttons

### DIFF
--- a/recipes/views.py
+++ b/recipes/views.py
@@ -76,13 +76,9 @@ class RecipeDetailView(DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         if self.request.user.is_authenticated:
-            from recipe_collections.models import Collection
             user_collections = Collection.objects.filter(user=self.request.user)
             context['recipe_collections'] = user_collections
-            recipe_in_collections = user_collections.filter(recipes=self.object)
-            context['recipe_in_collections_ids'] = [
-                collection.id for collection in recipe_in_collections
-            ]
+            context['recipe_in_collections_ids'] = set(user_collections.filter(recipes=self.object).values_list('id', flat=True))
         return context
 
 


### PR DESCRIPTION
Subject:

- fix: Conditionally show "Add" or "Remove" button for collections

Description:

- Issue : Users were shown an "Add to Collection" button even when a recipe was already in a collection. This created a confusing user experience and could lead to redundant actions.

- Causes :  The template's conditional logic was checking for a non-existent context variable, so the if statement to switch the button's text and action was never executed.

- Fixed :  The RecipeDetailView now passes a new context variable containing the IDs of all collections that already contain the recipe. The template's conditional logic was updated to correctly reference this variable, allowing the button to dynamically switch between "Add" and "Remove".