### PR TITLE
feat: Add Markdown support for recipe instructions field

### DIFF
--- a/recipehub/settings.py
+++ b/recipehub/settings.py
@@ -30,7 +30,6 @@ INSTALLED_APPS = [
     'recipes',
     'accounts',
     'recipe_collections',
-    'markdown_deux',
     'widget_tweaks',
 ]
 

--- a/recipehub/settings.py
+++ b/recipehub/settings.py
@@ -30,6 +30,7 @@ INSTALLED_APPS = [
     'recipes',
     'accounts',
     'recipe_collections',
+    'markdown_deux',
     'widget_tweaks',
 ]
 

--- a/recipes/templates/recipes/recipe_detail.html
+++ b/recipes/templates/recipes/recipe_detail.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load markdown_deux_tags %}
 
 {% block title %}{{ recipe.title }}{% endblock %}
 
@@ -71,7 +72,7 @@
     <div class="bg-white rounded-xl shadow-lg p-8">
         <h2 class="text-2xl font-bold text-gray-800 mb-4">Instructions</h2>
         <div class="prose max-w-none text-gray-700">
-            <p>{{ recipe.instructions }}</p>
+            <p>{{ recipe.instructions|linebreaksbr }}</p>
         </div>
     </div>
 </div>

--- a/recipes/templates/recipes/recipe_detail.html
+++ b/recipes/templates/recipes/recipe_detail.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load markdown_deux_tags %}
+{% load markdown_extras %}
 
 {% block title %}{{ recipe.title }}{% endblock %}
 
@@ -71,8 +71,8 @@
     </div>
     <div class="bg-white rounded-xl shadow-lg p-8">
         <h2 class="text-2xl font-bold text-gray-800 mb-4">Instructions</h2>
-        <div class="prose max-w-none text-gray-700">
-            <p>{{ recipe.instructions|linebreaksbr }}</p>
+        <div class="prose">
+            {{ recipe.instructions|markdownify|safe }}
         </div>
     </div>
 </div>

--- a/recipes/templates/recipes/recipe_form.html
+++ b/recipes/templates/recipes/recipe_form.html
@@ -47,7 +47,7 @@
                         {{ form.instructions.label }}
                     </label>
                     <textarea
-                    id="{{ form.instructions.id_for_label }}"
+                    id="instructions"
                     name="{{ form.instructions.name }}"
                     rows="5"
                     class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50"
@@ -134,5 +134,17 @@
 </div>
 
 {% include "scripts/ingredient_formset.html" %}
+
+<script>
+    var simplemde = new SimpleMDE({
+        element: document.getElementById("instructions"),
+        spellChecker: false,
+        forceSync: true,
+        previewRender: function(plainText) {
+            var html = SimpleMDE.prototype.markdown(plainText);
+            return "<div class='markdown-body'>" + html + "</div>";
+        }
+    });
+</script>
 
 {% endblock %}

--- a/recipes/templatetags/markdown_extras.py
+++ b/recipes/templatetags/markdown_extras.py
@@ -1,0 +1,8 @@
+import markdown
+from django import template
+
+register = template.Library()
+
+@register.filter
+def markdownify(text):
+    return markdown.markdown(text, extensions=["fenced_code", "tables"])

--- a/recipes/templatetags/markdown_extras.py
+++ b/recipes/templatetags/markdown_extras.py
@@ -1,10 +1,8 @@
 import markdown
-import bleach
 from django import template
 
 register = template.Library()
 
 @register.filter
 def markdownify(text):
-    html = markdown.markdown(text, extensions=["fenced_code", "tables"])
-    return bleach.clean(html)
+    return markdown.markdown(text, extensions=["fenced_code", "tables"])

--- a/recipes/templatetags/markdown_extras.py
+++ b/recipes/templatetags/markdown_extras.py
@@ -1,8 +1,10 @@
 import markdown
+import bleach
 from django import template
 
 register = template.Library()
 
 @register.filter
 def markdownify(text):
-    return markdown.markdown(text, extensions=["fenced_code", "tables"])
+    html = markdown.markdown(text, extensions=["fenced_code", "tables"])
+    return bleach.clean(html)

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,6 +13,28 @@
         body {
             font-family: 'Inter', sans-serif;
         }
+        .prose h1 {
+        font-size: 2rem;
+        font-weight: bold;
+        margin-top: 1rem;
+        margin-bottom: 0.5rem;
+      }
+      .prose h2 {
+        font-size: 1.5rem;
+        font-weight: bold;
+        margin-top: 0.75rem;
+        margin-bottom: 0.5rem;
+      }
+      .prose ul {
+        list-style: disc;
+        margin-left: 1.5rem;
+        margin-bottom: 0.75rem;
+      }
+      .prose ol {
+        list-style: decimal;
+        margin-left: 1.5rem;
+        margin-bottom: 0.75rem;
+      }
     </style>
 </head>
 <body class="bg-gray-100 min-h-screen flex flex-col">

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,6 +8,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css@5.5.1/github-markdown.min.css">
+    <script src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"></script>
     {% load static %}
     <style>
         body {

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,27 +14,28 @@
             font-family: 'Inter', sans-serif;
         }
         .prose h1 {
-        font-size: 2rem;
-        font-weight: bold;
-        margin-top: 1rem;
-        margin-bottom: 0.5rem;
-      }
-      .prose h2 {
-        font-size: 1.5rem;
-        font-weight: bold;
-        margin-top: 0.75rem;
-        margin-bottom: 0.5rem;
-      }
-      .prose ul {
-        list-style: disc;
-        margin-left: 1.5rem;
-        margin-bottom: 0.75rem;
-      }
-      .prose ol {
-        list-style: decimal;
-        margin-left: 1.5rem;
-        margin-bottom: 0.75rem;
-      }
+            font-size: 2rem;
+            font-weight: bold;
+            margin-top: 1rem;
+            margin-bottom: 0.5rem;
+        }
+        .prose h2 {
+            font-size: 1.5rem;
+            font-weight: bold;
+            margin-top: 0.75rem;
+            margin-bottom: 0.5rem;
+        }
+        .prose ul {
+            list-style: disc;
+            margin-left: 1.5rem;
+            margin-bottom: 0.75rem;
+        }
+        .prose ol {
+            list-style: decimal;
+            margin-left: 1.5rem;
+            margin-bottom: 0.75rem;
+        }
+     
     </style>
 </head>
 <body class="bg-gray-100 min-h-screen flex flex-col">


### PR DESCRIPTION
Subject:
feat: Add Markdown support for recipe instructions field

Description:

- Issue: Recipe instructions were being stored and displayed as plain text. Users had no way to format content (headings, lists, bold/italic), which made longer instructions hard to read.

- Causes: The instructions field was rendered directly in templates without Markdown processing, so formatting syntax like #, ** was not interpreted.

- Fixed: Integrated the markdown library and added a custom markdownify template filter. Updated the recipe detail template to render the instructions field with Markdown support, allowing headings, lists, bold, italic, and other formatting to display correctly.